### PR TITLE
Feature/on time set flow config block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 All notable changes to this project will be documented in this file.
+## Release 3.2.1
+
+### New features
+- Add 'OnTimeSet' FlowConfig block to react on time is set event, whether via NPT or manual action
 
 ## Release 3.2.0
 

--- a/CSK_Module_DateTime/project.mf.xml
+++ b/CSK_Module_DateTime/project.mf.xml
@@ -248,7 +248,38 @@ If set to false the NTP time is just printed to the log.</desc>
                     <desc>Function to get status if module is active.</desc>
                     <return desc="Status" multiplicity="1" name="status" type="bool"/>
                 </function>
+                <function name="clearFlowConfigRelevantConfiguration">
+                    <trait>released</trait>
+                </function>
             </serves>
+        </crown>
+        <crown name="DateTime_FC">
+            <trait>released</trait>
+            <serves/>
+            <crown name="OnTimeSet">
+                <trait>released</trait>
+                <desc>Event to notify the whether the datetime is set on the machine, it could be NTP or manual trigger </desc>
+                <serves>
+                    <event name="OnTimeSet">
+                        <trait>released</trait>
+                        <include>data-flow</include>
+                        <desc>Event to notify the whether the datetime is set on the machine, it could be NTP or manual trigger </desc>
+                        <param desc="" multiplicity="1" name="handle" type="handle"/>
+                        <param desc="" multiplicity="1" name="OnTimeSet" type="string"/>
+                    </event>
+                    <function name="create">
+                        <trait>released</trait>
+                        <return desc="" multiplicity="1" name="handle" type="handle"/>
+                    </function>
+                    <function name="register">
+                        <trait>released</trait>
+                        <param desc="" multiplicity="1" name="handle" type="handle"/>
+                        <param desc="" multiplicity="1" name="eventname" type="string"/>
+                        <param desc="" multiplicity="1" name="callback" type="string"/>
+                        <return desc="" multiplicity="1" name="success" type="bool"/>
+                    </function>
+                </serves>
+            </crown>
         </crown>
         <meta key="author">SICK AG</meta>
         <meta key="version">3.2.0</meta>

--- a/CSK_Module_DateTime/scripts/CSK_Module_DateTime.lua
+++ b/CSK_Module_DateTime/scripts/CSK_Module_DateTime.lua
@@ -43,6 +43,7 @@ _G.logHandle:applyConfig()
 -- Loading script regarding DateTime_Model
 -- Check this script regarding DateTime_Model parameters and functions
 _G.dateTime_Model = require('Configuration/DateTime/DateTime_Model')
+require('Configuration.DateTime.FlowConfig.DateTime_FlowConfig')
 
 if _G.availableAPIs.default == false then
   _G.logger:warning("CSK_DateTime: Relevant CROWN(s) not available on device. Module is not supported...")

--- a/CSK_Module_DateTime/scripts/Configuration/DateTime/DateTime_Controller.lua
+++ b/CSK_Module_DateTime/scripts/Configuration/DateTime/DateTime_Controller.lua
@@ -474,6 +474,13 @@ local function handleOnInitialDataLoaded()
 end
 Script.register("CSK_PersistentData.OnInitialDataLoaded", handleOnInitialDataLoaded)
 
+
+local function clearFlowConfigRelevantConfiguration()
+  --TODO
+end
+Script.serveFunction('CSK_DateTime.clearFlowConfigRelevantConfiguration', clearFlowConfigRelevantConfiguration)
+
+
 -- *************************************************
 -- END of functions for CSK_PersistentData module usage
 -- *************************************************

--- a/CSK_Module_DateTime/scripts/Configuration/DateTime/DateTime_Model.lua
+++ b/CSK_Module_DateTime/scripts/Configuration/DateTime/DateTime_Model.lua
@@ -89,6 +89,7 @@ dateTime_Model.parameters.ntpPeriodicUpdate = true -- periodic update of NTP
 dateTime_Model.parameters.ntpTimeout = 1000 -- NTP timeout
 dateTime_Model.parameters.systemTimeSource = 'MANUAL'  -- time source for system time: 'NTP', 'MANUAL'
 
+
 --**************************************************************************
 --********************** End Global Scope **********************************
 --**************************************************************************

--- a/CSK_Module_DateTime/scripts/Configuration/DateTime/FlowConfig/DateTime_FlowConfig.lua
+++ b/CSK_Module_DateTime/scripts/Configuration/DateTime/FlowConfig/DateTime_FlowConfig.lua
@@ -1,0 +1,16 @@
+--*****************************************************************
+-- Here you will find all the required content to provide specific
+-- features of this module via the 'CSK FlowConfig'.
+--*****************************************************************
+
+require('Configuration.DateTime.FlowConfig.DateTime_OnTimeSet')
+
+--- Function to react if FlowConfig was updated
+local function handleOnClearOldFlow()
+  --if _G.availableAPIs.default and _G.availableAPIs.specific then
+    if dateTime_Model.parameters.flowConfigPriority then
+      CSK_DateTime.clearFlowConfigRelevantConfiguration() --TODO
+    end
+  --end
+end
+Script.register('CSK_FlowConfig.OnClearOldFlow', handleOnClearOldFlow)

--- a/CSK_Module_DateTime/scripts/Configuration/DateTime/FlowConfig/DateTime_OnTimeSet.lua
+++ b/CSK_Module_DateTime/scripts/Configuration/DateTime/FlowConfig/DateTime_OnTimeSet.lua
@@ -1,0 +1,33 @@
+-- Block namespace
+local BLOCK_NAMESPACE = "DateTime_FC.OnTimeSet"
+local nameOfModule = 'CSK_DateTime'
+
+--*************************************************************
+--*************************************************************
+
+local function register(handle, _ , callback)
+  Container.remove(handle, "CB_Function")
+  Container.add(handle, "CB_Function", callback)
+
+  local function localCallback()
+    if callback ~= nil then
+      Script.callFunction(callback, 'CSK_DateTime.OnNewStatusIsTimeSet') -- adapt this accordingly
+    else
+      _G.logger:warning(nameOfModule .. ": " .. BLOCK_NAMESPACE .. ".CB_Function missing!")
+    end
+  end
+  Script.register('CSK_FlowConfig.OnNewFlowConfig', localCallback)
+
+  return true
+end
+Script.serveFunction(BLOCK_NAMESPACE ..".register", register)
+
+--*************************************************************
+--*************************************************************
+
+local function create()
+  local container = Container.create()
+  Container.add(container, "CB_Function", "")
+  return(container)
+end
+Script.serveFunction(BLOCK_NAMESPACE .. ".create", create)


### PR DESCRIPTION
# Version 3.2.1

## New features
- Add 'OnTimeSet' FlowConfig block to react on time is set event, whether via NPT or manual action
### ...

## Improvements

### ...

## Bugfix

### ...

## Following tasks were checked

- [x] Module is coded and structured according to the "Developing guideline for modules" described within the CSK documentation
- [x] All functions/events/parameters are documented within the manifest documentation
- [x] The manifest description of the main CROWN includes main information about the purpose of the module and how to use it in general
- [x] API docu based on the manifest was created and stored within the "docu"-folder of the repository
- [x] Internal LUA code documentation exists for variables and non served functions
- [x] All relevant infos are logged via the SharedLogger 'ModuleLogger'
- [ ] Module supports persistent data feature based on 'CSK_Module_PersistentData'
- [ ] Module supports user management based on 'CSK_Module_UserManagement'
- [ ] No open "ToDos" within the code or at least clearly explained comments why they exist...
- [x] "Version" key in app manifest was updated following semantic versioning (and use '0.x.y' for test / experimental modules which are not yet ready to be officially released)
- [ ] Meaningful IDs used for UI elements
- [x] Module was tested on an AppSpace device (at least on SICK AppEngine) with no error message
- [x] README.md is up to date (incl. info of device + firmware the module was tested with)
- [x] CHANGELOG.md is up to date
